### PR TITLE
Fix installer: run in parent shell instead of child

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,18 @@ Add extra information of your AWS CodeBuild build via environment variables.
 
 Add the following command to the `install` or `pre_build` phase of your buildspec:
 
-    bash -c "$(curl -fsSL https://raw.githubusercontent.com/thii/aws-codebuild-extras/master/install)"
+    curl -fsSL https://raw.githubusercontent.com/thii/aws-codebuild-extras/master/install >> extras.sh && . ./extras.sh
 
+Or for better readability, break the installation into two steps.
+For example in the `install` phase:
+```
+phases:
+  install:
+    commands:
+      - echo Installing codebuild-extras...
+      - curl -fsSL https://raw.githubusercontent.com/thii/aws-codebuild-extras/master/install >> extras.sh
+      - . ./extras.sh
+```
 |NAME|VALUE
 |---|---|
 |CI|true|

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,8 @@ version: 0.2
 phases:
   install:
     commands:
-      - bash -c "$(curl -fsSL https://raw.githubusercontent.com/thii/aws-codebuild-extras/master/install)"
+      - curl -fsSL https://raw.githubusercontent.com/thii/aws-codebuild-extras/master/install >> extras.sh
+      - . ./extras.sh
   build:
     commands:
       - # Do nothing


### PR DESCRIPTION
The current installation method of spawning a child shell with `bash -c $(curl ...)` does not work for making the extra env vars available to the main CodeBuild Container's environment. 

This changeset: 
- fixes the issue by capturing the `curl`-ed installer script in a file which can be executed by the top-level shell.
- updates example buildspec.yml and README doc to reflect the fix