### PR TITLE
Change CODEBUILD_GIT_BRANCH fallback strategy

### DIFF
--- a/install
+++ b/install
@@ -7,8 +7,7 @@ export CODEBUILD_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --ou
 
 export CODEBUILD_GIT_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
 if [ "$CODEBUILD_GIT_BRANCH" = "" ] ; then
-  CODEBUILD_GIT_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }')";
-  export CODEBUILD_GIT_BRANCH=${CODEBUILD_GIT_BRANCH#remotes/origin/};
+  export CODEBUILD_GIT_BRANCH="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')";
 fi
 
 export CODEBUILD_GIT_CLEAN_BRANCH="$(echo $CODEBUILD_GIT_BRANCH | tr '/' '.')"


### PR DESCRIPTION
* Fall back to the method from https://stackoverflow.com/a/52947601/1661089 for resolving CODEBULD_GIT_BRANCH if in a detached HEAD state

Proposed for https://github.com/thii/aws-codebuild-extras/issues/13